### PR TITLE
Feature/api post req

### DIFF
--- a/controllers/ai-controller.js
+++ b/controllers/ai-controller.js
@@ -6,34 +6,45 @@ dotenv.config();
 const api_key = process.env.OPENAI_API_KEY;
 
 async function getAIResponse(req, res) {
-  console.log(api_key);
+  try {
+    console.log(api_key);
 
-  const openai = new OpenAI({ apiKey: api_key });
+    const openai = new OpenAI({ apiKey: api_key });
 
-  const startTime = performance.now();
+    const startTime = performance.now();
 
-  const completion = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [
-      {
-        role: "system",
-        content: "You are a helpful assistant for repharsing emails.",
-      },
-      {
-        role: "user",
-        content: `Rephrase and improve the attached email. Keep the length same as the original email. Just the body of email is enough. Give the final text in one line. Here is the email: ${req.body.email}`,
-      },
-    ],
-    store: true,
-  });
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: "You are a helpful assistant for rephrasing emails.",
+        },
+        {
+          role: "user",
+          content: `Rephrase and improve the attached email. Keep the length the same as the original email. Just the body of email is enough. Give the final text in one line. Here is the email: ${req.body.email}`,
+        },
+      ],
+    });
 
-  const endTime = performance.now();
-  const responseObject = JSON.stringify({
-    response: completion.choices[0].message.content,
-    time: endTime - startTime,
-  });
-  console.log(responseObject);
-  res.send(responseObject).status(200);
+    const endTime = performance.now();
+    const durationMs = endTime - startTime;
+
+    const durationSeconds = (durationMs / 1000).toFixed(2);
+
+    const formattedTime =
+      durationSeconds >= 60
+        ? `${(durationSeconds / 60).toFixed(2)} minutes`
+        : `${durationSeconds} seconds`;
+
+    res.status(200).json({
+      response: completion.choices[0].message.content,
+      time: formattedTime,
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Something went wrong" });
+  }
 }
 
 export default getAIResponse;

--- a/routes/root.js
+++ b/routes/root.js
@@ -1,10 +1,13 @@
 import express from "express";
 import "dotenv/config";
+import getAIResponse from "../controllers/ai-controller.js";
 
 const root = express.Router();
 
 root.get("/", (req, res) => {
   res.send("Hello from roooooooot!");
 });
+
+root.post("/ai-response", getAIResponse);
 
 export default root;


### PR DESCRIPTION
- Formatted response time to display in seconds or minutes.
- Wrapped `getAIResponse` in a try/catch block for better error handling.
- Removed `store: true` since it was unnecessary.
- Example request attached.
- Edit: tested with a small email body because the amount of credit on the account is unknown and we want it to last through multiple testing rounds.

Request:

POST /ai-response 
Content-Type: application/json

```
{
  "email": "Hey, can we reschedule our meeting?"
}
```


Response:

```
{
  "response": "Hello, would it be possible to reschedule our meeting?",
  "time": "0.87 seconds"
}

```